### PR TITLE
Update schedule lib to fix date.format error

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,7 +14,7 @@
         "@nestjs/jwt": "^9.0.0",
         "@nestjs/passport": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",
-        "@nestjs/schedule": "^2.1.0",
+        "@nestjs/schedule": "^3.0.1",
         "@nestjs/serve-static": "^3.0.0",
         "@nestjs/typeorm": "^9.0.1",
         "@types/cache-manager": "^4.0.2",
@@ -1693,25 +1693,17 @@
       }
     },
     "node_modules/@nestjs/schedule": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-2.1.0.tgz",
-      "integrity": "sha512-4Xaw56WiW3VsxEPPnj/iDtfjcO+sUZyYAeRxD0gnF5havncxjAnv52Iw7UH3DuzzUA784xPGgGje3Fq0Gu925g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-3.0.1.tgz",
+      "integrity": "sha512-4CAFu4rE/QPYnz/icRg3GiuLmY1bXopG8bWTJ9d7bXzaHBaPKIjGvZ20wsK8P+MncrVCkmK0iYhQrNj0cwX9+A==",
       "dependencies": {
-        "cron": "2.0.0",
-        "uuid": "8.3.2"
+        "cron": "2.3.1",
+        "uuid": "9.0.0"
       },
       "peerDependencies": {
-        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0",
-        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "reflect-metadata": "^0.1.12"
-      }
-    },
-    "node_modules/@nestjs/schedule/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@nestjs/schematics": {
@@ -3957,11 +3949,11 @@
       "devOptional": true
     },
     "node_modules/cron": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/cron/-/cron-2.0.0.tgz",
-      "integrity": "sha512-RPeRunBCFr/WEo7WLp8Jnm45F/ziGJiHVvVQEBSDTSGu6uHW49b2FOP2O14DcXlGJRLhwE7TIoDzHHK4KmlL6g==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-2.3.1.tgz",
+      "integrity": "sha512-1eRRlIT0UfIqauwbG9pkg3J6CX9A6My2ytJWqAXoK0T9oJnUZTzGBNPxao0zjodIbPgf8UQWjE62BMb9eVllSQ==",
       "dependencies": {
-        "luxon": "^1.23.x"
+        "luxon": "^3.2.1"
       }
     },
     "node_modules/cross-spawn": {
@@ -6972,11 +6964,11 @@
       }
     },
     "node_modules/luxon": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/macos-release": {
@@ -11697,19 +11689,12 @@
       }
     },
     "@nestjs/schedule": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-2.1.0.tgz",
-      "integrity": "sha512-4Xaw56WiW3VsxEPPnj/iDtfjcO+sUZyYAeRxD0gnF5havncxjAnv52Iw7UH3DuzzUA784xPGgGje3Fq0Gu925g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-3.0.1.tgz",
+      "integrity": "sha512-4CAFu4rE/QPYnz/icRg3GiuLmY1bXopG8bWTJ9d7bXzaHBaPKIjGvZ20wsK8P+MncrVCkmK0iYhQrNj0cwX9+A==",
       "requires": {
-        "cron": "2.0.0",
-        "uuid": "8.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
+        "cron": "2.3.1",
+        "uuid": "9.0.0"
       }
     },
     "@nestjs/schematics": {
@@ -13492,11 +13477,11 @@
       "devOptional": true
     },
     "cron": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/cron/-/cron-2.0.0.tgz",
-      "integrity": "sha512-RPeRunBCFr/WEo7WLp8Jnm45F/ziGJiHVvVQEBSDTSGu6uHW49b2FOP2O14DcXlGJRLhwE7TIoDzHHK4KmlL6g==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-2.3.1.tgz",
+      "integrity": "sha512-1eRRlIT0UfIqauwbG9pkg3J6CX9A6My2ytJWqAXoK0T9oJnUZTzGBNPxao0zjodIbPgf8UQWjE62BMb9eVllSQ==",
       "requires": {
-        "luxon": "^1.23.x"
+        "luxon": "^3.2.1"
       }
     },
     "cross-spawn": {
@@ -15797,9 +15782,9 @@
       }
     },
     "luxon": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg=="
     },
     "macos-release": {
       "version": "2.5.0",

--- a/server/package.json
+++ b/server/package.json
@@ -27,7 +27,7 @@
     "@nestjs/jwt": "^9.0.0",
     "@nestjs/passport": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
-    "@nestjs/schedule": "^2.1.0",
+    "@nestjs/schedule": "^3.0.1",
     "@nestjs/serve-static": "^3.0.0",
     "@nestjs/typeorm": "^9.0.1",
     "@types/cache-manager": "^4.0.2",


### PR DESCRIPTION
Fix for error originating from the cron library

uncaughtException: date.format is not a function\nTypeError: date.format is not a function\n    at CT._getNextDateFrom (/build/server/index.js:309261:79)\n    at CT.sendAt (/build/server/index.js:309175:17)\n    at CT.getTimeout (/build/server/index.js:309192:29)\n    at CJ.start (/build/server/index.js:308887:31)\n    at Timeout.callbackWrapper [as _onTimeout] (/build/server/index.js:308940:11)\n    at listOnTimeout (internal/timers.js:557:17)\n    at processTimers (internal/timers.js:500:7)